### PR TITLE
Prevent bouncing when colliding with walls

### DIFF
--- a/Assets/Scenes/Maze.unity
+++ b/Assets/Scenes/Maze.unity
@@ -147,6 +147,26 @@ Prefab:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 114622369988110540, guid: a47c5a82bfeadfb4992ce358dfdee92a,
+        type: 2}
+      propertyPath: movementSpeed
+      value: 3000
+      objectReference: {fileID: 0}
+    - target: {fileID: 54859979636070298, guid: a47c5a82bfeadfb4992ce358dfdee92a,
+        type: 2}
+      propertyPath: m_Drag
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 54859979636070298, guid: a47c5a82bfeadfb4992ce358dfdee92a,
+        type: 2}
+      propertyPath: m_AngularDrag
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114622369988110540, guid: a47c5a82bfeadfb4992ce358dfdee92a,
+        type: 2}
+      propertyPath: rotationSpeed
+      value: 200
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a47c5a82bfeadfb4992ce358dfdee92a, type: 2}
   m_IsPrefabParent: 0
@@ -510,6 +530,31 @@ Prefab:
     - target: {fileID: 4518450829737050, guid: 208aa33fd5f5f4d4aba5358198b163da, type: 2}
       propertyPath: m_RootOrder
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114430408247785142, guid: 208aa33fd5f5f4d4aba5358198b163da,
+        type: 2}
+      propertyPath: movementSpeed
+      value: 3000
+      objectReference: {fileID: 0}
+    - target: {fileID: 54335513982128230, guid: 208aa33fd5f5f4d4aba5358198b163da,
+        type: 2}
+      propertyPath: m_Drag
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 54335513982128230, guid: 208aa33fd5f5f4d4aba5358198b163da,
+        type: 2}
+      propertyPath: m_AngularDrag
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 54335513982128230, guid: 208aa33fd5f5f4d4aba5358198b163da,
+        type: 2}
+      propertyPath: m_Mass
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114430408247785142, guid: 208aa33fd5f5f4d4aba5358198b163da,
+        type: 2}
+      propertyPath: rotationSpeed
+      value: 200
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 208aa33fd5f5f4d4aba5358198b163da, type: 2}

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -12,25 +12,25 @@ public class PlayerMovement : MonoBehaviour
     private Rigidbody body;
 
 	void Start ()
-    {
-        body = GetComponent<Rigidbody>();
+        {
+            body = GetComponent<Rigidbody>();
 
-        GetComponent<MeshRenderer>().material.color = playerColor;
+            GetComponent<MeshRenderer>().material.color = playerColor;
 	}
 	
 	void Update ()
-    {
-        float vertical = Input.GetAxis("Vertical_" + id);
-        float horizontal = Input.GetAxis("Horizontal_" + id);
-
-        if(horizontal != 0)
         {
-            transform.Rotate(transform.up, horizontal * Time.deltaTime * rotationSpeed);
-        }
+            float vertical = Input.GetAxis("Vertical_" + id);
+            float horizontal = Input.GetAxis("Horizontal_" + id);
 
-        if(vertical != 0)
-        {
-            body.velocity = transform.forward * Time.deltaTime * vertical * movementSpeed;
-        }
+            if (horizontal != 0)
+            {
+                transform.Rotate(transform.up, horizontal * Time.deltaTime * rotationSpeed);
+            }
+
+            if (vertical != 0)
+            {
+                body.AddForce(transform.forward * Time.deltaTime * vertical * movementSpeed);
+            }
 	}
 }

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -4,7 +4,7 @@
 PhysicsManager:
   m_ObjectHideFlags: 0
   serializedVersion: 3
-  m_Gravity: {x: 0, y: -9.81, z: 0}
+  m_Gravity: {x: 0, y: -98.1, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
   m_SleepThreshold: 0.005


### PR DESCRIPTION
Previously when colliding with walls players would clip into the
wall and then bounce back. This commit prevents this problem from
occurring by preventing the player from moving into the wall in
the first place. This is done by using AddForce() instead of
setting the player's velocity directly.

This change in turn necessiated modifying other contants,
including increasing the player speed and drag, as well as
increasing gravity to make players fall at a normal speed (to
counteract the increased drag). The Angular drag has also been
eliminated completely.